### PR TITLE
Update common.mk

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -105,6 +105,7 @@ PRODUCT_PACKAGES += \
     tinycap \
     audio_policy.default \
     audio.a2dp.default \
+    audio.r_submix.default \
     audio.usb.default
 
 # DRM


### PR DESCRIPTION
It does the trick to support chromecast mirroring using this app: http://forum.xda-developers.com/hardware-hacking/chromecast/experimental-enable-mirroring-device-t2812193
